### PR TITLE
Using go v1.20 in tokenizers to be built in hugot with this version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/knights-analytics/tokenizers
 
-go 1.22
+go 1.20
 
 require github.com/stretchr/testify v1.9.0
 


### PR DESCRIPTION
ref: https://github.com/knights-analytics/hugot/issues/22